### PR TITLE
Member variables $cache_hits and $cache_misses should be public

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -3,7 +3,7 @@
 Plugin Name: WordPress APCu Object Cache Backend
 Plugin URI: https://github.com/l3rady/WordPress-APCu-Object-Cache
 Description: APCu backend for WordPress' Object Cache
-Version: 1.0
+Version: 1.0.1
 Author: Scott Cariss
 Author URI: http://l3rady.com
 */

--- a/object-cache.php
+++ b/object-cache.php
@@ -283,14 +283,14 @@ class WP_Object_Cache {
 	 * @var int Keeps count of how many times the
 	 *    cache was successfully received from APCu
 	 */
-	private $cache_hits = 0;
+	public $cache_hits = 0;
 
 
 	/**
 	 * @var int Keeps count of how many times the
 	 *    cache was not successfully received from APCu
 	 */
-	private $cache_misses = 0;
+	public $cache_misses = 0;
 
 
 	/**


### PR DESCRIPTION
Hi,

I've seen that, in your implementation of the `WP_Object_Cache` class, the member variables `$cache_hits` and `$cache_misses` are private. Those variables are public in [WordPress's original implementation](https://developer.wordpress.org/reference/classes/wp_object_cache/).

This can lead to problems with plugins which expect them to be public. For example, I've run into problems when using the "Query Monitor" plugin. I keep getting these error messages in my error log:
```
[Wed Jan 10 02:30:34.723018 2018] [:error] [pid 9729] [client 127.0.0.1:36002] PHP Fatal error:  Uncaught Error: Cannot access private property WP_Object_Cache::$cache_hits in /data/wordpress/www/wp-content/plugins/query-monitor/collectors/cache.php:33
``` 