### PR TITLE
When using batcache, a fatal error occurs (call to undefined function wp_suspend_cache_addition)

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -421,7 +421,7 @@ class WP_Object_Cache
      */
     public function add($key, $var, $group = 'default', $ttl = 0)
     {
-        if (wp_suspend_cache_addition()) {
+        if (function_exists('wp_suspend_cache_addition') && wp_suspend_cache_addition()) {
             return false;
         }
 


### PR DESCRIPTION
When using Batcache, wp_cache_add() is called before wp_suspend_cache_addition() is defined causing a fatal error. This is due to Batcache loading the object cache before it is normally added. As such, wp_suspend_cache_addition() is not defined.

This issue can be resolved by adding a function_exists() call before using wp_suspend_cache_addition().